### PR TITLE
feat: send to algolia only on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 cache: bundler
 language: ruby
 sudo: false
-script:
-  - bundle exec jekyll algolia push
+deploy:
+  - provider: script
+    script: bundle exec jekyll algolia push
+    on:
+      branch: master


### PR DESCRIPTION
Ne pas indexed à chaque PR mais seulement sur le merge dans master.

Cela permet de ne pas utiliser les appels api :)