### PR TITLE
fix(readme): wrong path for author image

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Votre Bio
 
 **3 - Ajoutez votre avatar**
 
-Ajoutez votre avatar dans le dossier `/img/login.jpg`.
+Ajoutez votre avatar dans le dossier `/img/authors/<votre_login>.jpg`.
 
 **4 - Faite votre pull request**
 


### PR DESCRIPTION
Wrong path for author image in README

`/img/login.jpg` -> `/img/authors/<votre_login>.jpg`