### PR TITLE
chore(plugin): bump jekyll-seo-tag plugin to 2.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gem 'jekyll', '3.4.3'
 gem 'jekyll-paginate', '1.1.0'
-gem 'jekyll-seo-tag', '2.1.0'
+gem 'jekyll-seo-tag', '2.2.3'
 gem 'rouge', '1.11.1'
 
 group :test do


### PR DESCRIPTION
bump jekyll-seo-tag plugin to 2.2.3