### PR TITLE
fix(seo): change heading level to avoid multiple h1 in post

### DIFF
--- a/_posts/2017-07-18-video-live-dash-hls.md
+++ b/_posts/2017-07-18-video-live-dash-hls.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Les principaux formats de flux video live DASH et HLS"
 excerpt: Le HLS et le DASH, deux protocoles pour les streamer tous.
-authors: 
+authors:
     - jbernard
 permalink: /fr/video-live-dash-hls/
 date: '2017-07-18 12:00:00 +0100'
@@ -19,11 +19,11 @@ cover: /assets/2017-07-12-video-live-dash-hls/cover.jpg
 
 Bien qu'elles soient utilisées par des grands noms comme Apple, Microsoft, Youtube ou bien Netflix, les technologies de streaming video ne sont pas parmi les plus connues.
 
-# Préambule
+## Préambule
 
 Cet article traite des deux grandes technologies permettant le streaming vidéo sur une application web. Le HLS et le DASH seront donc ici détaillés afin d'en comprendre le fonctionnement général.
 
-# Le HLS
+## Le HLS
 
 Le HLS (HTTP Live Streaming) est une protocole de streaming audio/video conçu par Apple à la fin des année 2000, à la base pour le lecteur QuickTime. Comme son nom l'indique, ce protocole utilise le HTTP comme potocole de transport, ce qui le rend très adaptable et facilement utilisable via un Nginx ou autre Apache.
 
@@ -31,15 +31,14 @@ Au même titre que les autres protocoles servant les même objectifs, le HLS env
 
 De grandes plateformes de streaming utilisent ce protocole pour servir leurs streams video live ou leurs replays. La plateforme Twitch.js typiquement, premier site mondial de streaming de jeux video, nous servira d'exemple tout au long de cette partie.
 
-Fonctionnement
---------------
+### Fonctionnement
 
-Un diagramme vaut sûrement mieux qu'un long discours : 
+Un diagramme vaut sûrement mieux qu'un long discours :
 
 ![Diagramme de fonctionnement - HLS ](/assets/2017-07-12-video-live-dash-hls/diagram_HLS.png?raw=true)
 
 On voit ici le workflow permettant à l'audio/vidéo brut d'arriver sous forme de streaming au client.
-Les fichiers segmentés, le plus souvent au format MPEG-2 TS, sont accessibles via un "manifest", un fichier index au format M3U qui décrit les différents segments du contenu ainsi que des métadata que le client peut/doit utiliser. Ce fichier est basiquement une playlist d'URL. 
+Les fichiers segmentés, le plus souvent au format MPEG-2 TS, sont accessibles via un "manifest", un fichier index au format M3U qui décrit les différents segments du contenu ainsi que des métadata que le client peut/doit utiliser. Ce fichier est basiquement une playlist d'URL.
 
 L'exemple de fichier M3U ci-dessous provient d'un live de la plateforme Twitch.tv :
 
@@ -66,13 +65,13 @@ index-0000009184-Juro.ts
 ```
 
 Les lignes du fichier commençant par un `#` décrivent des métadata, les autres indiquent les URL des fichiers TS qui forment le contenu.
-Parmi les données les plus importantes, on retrouve : 
-- `#EXTM3U` : Genre de shebang indiquant le type de fichier manifest. Ici sans surprise, un fichier M3U. 
+Parmi les données les plus importantes, on retrouve :
+- `#EXTM3U` : Genre de shebang indiquant le type de fichier manifest. Ici sans surprise, un fichier M3U.
 - `#EXT-X-VERSION` : Version du protocole HLS à utiliser.
 - `#EXT-X-MEDIA-SEQUENCE` : Le nombre de séquences précédant la première URL du fichier.
 - `#EXTINF` : Durée de la séquence pointée par l'URL située sur la ligne suivante.
 
-L'exemple suivant montre un format de fichier M3U gérant l'adaptive streaming : 
+L'exemple suivant montre un format de fichier M3U gérant l'adaptive streaming :
 ```
 #EXTM3U
 #EXT-X-VERSION:6
@@ -84,16 +83,15 @@ live/high.m3u8
 live/low.m3u8
 ```
 
-Chaque balise `#EXT-X-STREAM-INF` indique les données nécéssaires à la lecture du segment, chacun d'entre eux d'une qualité et d'un encodage donnés. Ainsi, le client compatible pourra passer d'une qualité à une autre en temps réel, en fonction de la bande passante disponible ou du choix de l'utilisateur. Le diagramme suivant illustre d'ailleurs très bien cette possibilité :   
+Chaque balise `#EXT-X-STREAM-INF` indique les données nécéssaires à la lecture du segment, chacun d'entre eux d'une qualité et d'un encodage donnés. Ainsi, le client compatible pourra passer d'une qualité à une autre en temps réel, en fonction de la bande passante disponible ou du choix de l'utilisateur. Le diagramme suivant illustre d'ailleurs très bien cette possibilité :
 
 ![Fichier M3U - HLS ](/assets/2017-07-12-video-live-dash-hls/HLS_Figure_1.jpg?raw=true)
 
-Librairie JS
---------------------
+### Librairie JS
 
 La librairie open-source [hls.js](https://github.com/video-dev/hls.js) est certainement l'une des plus complètes quand il s'agit d'implémenter un client gérant le HTTP Live Streaming. Utilisée notamment par Canal+ et Dailymotion, hls.js est compatible avec un grand nombre de browsers et embarque des fonctionnalités avancées, comme la gestion de l'adaptive streaming ou le multi-thread (si le navigateur client est compatible) pour améliorer entre autre la fluidité de la mise en cache.
 
-hls.js dispose d'une [API](https://github.com/video-dev/hls.js/blob/master/doc/API.md) très complète (et très bien documentée !) qui permet de gérer la vidéo et le flux directement depuis le Javascript. Exemple de base d'implémentation : 
+hls.js dispose d'une [API](https://github.com/video-dev/hls.js/blob/master/doc/API.md) très complète (et très bien documentée !) qui permet de gérer la vidéo et le flux directement depuis le Javascript. Exemple de base d'implémentation :
 ```html
 <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
 <video id="video"></video>
@@ -113,18 +111,17 @@ hls.js dispose d'une [API](https://github.com/video-dev/hls.js/blob/master/doc/A
 Une démo live est disponible [ici](http://video-dev.github.io/hls.js/demo).
 
 
-# Le DASH
+## Le DASH
 
 Le Moving Picture Expert Group, plus connu sous son acronyme MPEG, a commencé la conception du MPEG-DASH en 2010. Le DASH (Dynamic Adaptive Streaming over HTTP) est ensuite devenu un standard internationnal à la fin de l'année 2011. C'est d'ailleurs la seule solution de streaming certifiée [ISO](http://mpeg.chiariglione.org/standards/mpeg-dash).
 
-Utilisé lui aussi par de très grandes plateformes comme Youtube ou Netflix, le DASH est assez semblable au HLS dans son fonctionnement général : des fichiers séquencés répertoriés dans un fichier servant de playlist. 
+Utilisé lui aussi par de très grandes plateformes comme Youtube ou Netflix, le DASH est assez semblable au HLS dans son fonctionnement général : des fichiers séquencés répertoriés dans un fichier servant de playlist.
 
 Le DASH, en plus d'étre normalisé et standardisé ISO, dispose de plusieurs fonctionnalités introuvables dans les autres technologies similaires, au prix d'une complexité un peu plus élevée.
 
-Fonctionnement
-------------
+### Fonctionnement
 
-Ne changeons pas une équipe qui gagne et commençons par un bon diagramme : 
+Ne changeons pas une équipe qui gagne et commençons par un bon diagramme :
 
 ![Diagramme de fonctionnement - DASH ](/assets/2017-07-12-video-live-dash-hls/diagram_DASH.png?raw=true)
 
@@ -190,7 +187,7 @@ type="static">
 </MPD>
 ```
 
-Nous avons donc ici du XML classique, chaque tag donnant des informations spécifiques. Voyons ensemble les tag principaux par ordre hierarchique : 
+Nous avons donc ici du XML classique, chaque tag donnant des informations spécifiques. Voyons ensemble les tag principaux par ordre hierarchique :
 
 - `<MPD>` : Décrit les métadata du fichier, sa version, la version du DASH utilisée, la durée total du contenu...
 - `<AdaptationSet>` : Une adaption est l'un des éléments du contenu, pas exemple la vidéo ou l'audio.
@@ -200,16 +197,15 @@ Nous avons donc ici du XML classique, chaque tag donnant des informations spéci
 
 Il peut être intéréssant de noter que le DASH supporte les DRM, pour diffuser du contenu protégé. Il permet aussi d'utiliser n'importe quel codec audio/vidéo, ce qui le rend particulièrement adaptable.
 
-Librairie JS
---------------------
+### Librairie JS
 
 L'une des librairies open-source les plus complètes pour implémenter un client DASH est sans doute le [Rx-Player](https://github.com/canalplus/rx-player), une librairie maintenue par Canal +. Elle permet de jouer aussi bien du DASH live que du replay, utilisable via une [API](https://github.com/canalplus/rx-player/blob/master/doc/api/index.md) très complète et dont le niveau de documentation est assez incroyable. Le tout est utilisé en production, notamment dans certaines box Canal +.
 
 Je leur laisse le soins d'expliquer [pourquoi](https://github.com/canalplus/rx-player#why-a-new-player-why-rx) le Rx-player est au-dessus quand il s'agit de la délicate mission d'implementer un player DASH. Il implémente aussi le Smooth Streaming (un autre protocole de streaming moins connu), si le coeur vous en dit.
 
-Si vous n'êtes pas convaincu, je vous laisser jeter un oeil à leur [démo](http://developers.canal-plus.com/rx-player/). 
+Si vous n'êtes pas convaincu, je vous laisser jeter un oeil à leur [démo](http://developers.canal-plus.com/rx-player/).
 
-# Conclusion
+## Conclusion
 
 Les deux protocoles présentés dans cet article partagent donc de nombreuses ressemblances dans leur fonctionnement général respectif.
 
@@ -218,7 +214,7 @@ Le DASH est un peu plus complexe, mais il offre des possibilités incroyables si
 
 Il ne serait pas fair-play de finir cet article sans au moins mentionner deux autre grandes technologies de streaming : Le MSS (Microsoft Smooth Streaming) et le HDS (HTTP Dynamic Streaming). Moins connu et disposant de fonctionnalités qui leurs sont propres, je vous laisse consulter à leurs sujets cet excellent [article](https://bitmovin.com/mpeg-dash-vs-apple-hls-vs-microsoft-smooth-streaming-vs-adobe-hds/) (en anglais) comparant, fonctionnalité par fonctionnalité, les quatre protocoles.
 
-# Références
+## Références
 
 * [ Spécification HLS - Apple ](https://developer.apple.com/streaming/)
 * [ Librairie hls.js - Github ](https://github.com/video-dev/hls.js/tree/master)

--- a/_posts/2017-07-19-video-live-dash-hls.md
+++ b/_posts/2017-07-19-video-live-dash-hls.md
@@ -5,8 +5,8 @@ excerpt: Le HLS et le DASH, deux protocoles pour les streamer tous.
 authors:
     - jbernard
 permalink: /fr/video-live-dash-hls/
-date: '2017-07-18 12:00:00 +0100'
-date_gmt: '2017-07-18 12:00:00 +0100'
+date: '2017-07-19 12:00:00 +0100'
+date_gmt: '2017-07-19 12:00:00 +0100'
 categories:
     - JS
     - Stream Video


### PR DESCRIPTION
- L'article contient des `<h1>` ce qui n'est pas recommandé pour des raisons SEO

  - Je descend d'un niveau tout les titres
`<h2>` -> `<h3>`
`<h1>` -> `<h2>`

- update date -> `2017-07-19`