### PR TITLE
feeat(deployment): use branch name as environment

### DIFF
--- a/bin/deploy-pr.sh
+++ b/bin/deploy-pr.sh
@@ -11,7 +11,7 @@ then
     bundle exec jekyll build
 
     # create deployment
-    DEPLOYMENT_ID=$(curl --silent -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -H "Accept: application/vnd.github.ant-man-preview+json" -X POST -d '{"ref":"'"$TRAVIS_PULL_REQUEST_BRANCH"'","environment":"dev","required_contexts":[]}' "https://api.github.com/repos/eleven-labs/eleven-labs.github.io/deployments" | jq -r ".id")
+    DEPLOYMENT_ID=$(curl --silent -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -H "Accept: application/vnd.github.ant-man-preview+json" -X POST -d '{"ref":"'"$TRAVIS_PULL_REQUEST_BRANCH"'","environment":"'"$TRAVIS_PULL_REQUEST_BRANCH"'","required_contexts":[]}' "https://api.github.com/repos/eleven-labs/eleven-labs.github.io/deployments" | jq -r ".id")
 
     # upload files
     aws s3 cp "_site/" "s3://dev.blog.eleven-labs.com/$TRAVIS_PULL_REQUEST_BRANCH" --recursive

--- a/bin/deploy-pr.sh
+++ b/bin/deploy-pr.sh
@@ -11,7 +11,7 @@ then
     bundle exec jekyll build
 
     # create deployment
-    DEPLOYMENT_ID=$(curl --silent -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -H "Accept: application/vnd.github.ant-man-preview+json" -X POST -d '{"ref":"'"$TRAVIS_PULL_REQUEST_BRANCH"'","environment":"'"$TRAVIS_PULL_REQUEST_BRANCH"'","required_contexts":[]}' "https://api.github.com/repos/eleven-labs/eleven-labs.github.io/deployments" | jq -r ".id")
+    DEPLOYMENT_ID=$(curl --silent -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -H "Accept: application/vnd.github.ant-man-preview+json" -X POST -d '{"ref":"'"$TRAVIS_PULL_REQUEST_BRANCH"'","environment":"'"$TRAVIS_PULL_REQUEST_BRANCH"'","required_contexts":[],"auto_merge":false}' "https://api.github.com/repos/eleven-labs/eleven-labs.github.io/deployments" | jq -r ".id")
 
     # upload files
     aws s3 cp "_site/" "s3://dev.blog.eleven-labs.com/$TRAVIS_PULL_REQUEST_BRANCH" --recursive


### PR DESCRIPTION
## Description

Quand 2 PRs sont déployées en dev, le premier déploiement est marqué inactif par le deuxieme.
On évite ce comportement en utilisant un environnement par PR

also disable auto_merge on deploy