### PR TITLE
feat(authors): use permalink

### DIFF
--- a/_authors/TEMPLATE-AUTOR
+++ b/_authors/TEMPLATE-AUTOR
@@ -3,5 +3,6 @@ layout: author
 login: votre_login
 title: Prénom Nom
 twitter: Compte twitter
+permalink: /authors/votre_login/
 ---
 Votre Bio

--- a/_authors/VEBERArnaud.md
+++ b/_authors/VEBERArnaud.md
@@ -3,5 +3,6 @@ layout: author
 login: VEBERArnaud
 title: Arnaud Veber
 twitter: VEBERArnaud
+permalink: /authors/VEBERArnaud/
 ---
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh urna, auctor sit amet vehicula quis, feugiat eu sem. Duis sed lorem nibh. Nam pretium finibus sodales. Vivamus elementum ultricies magna, sit amet hendrerit ex fringilla eget. Morbi facilisis, lorem nec eleifend malesuada, erat lorem euismod urna, et interdum libero mi at leo. Aliquam erat volutpat. Duis et odio id metus feugiat interdum. Mauris sed elementum sem.

--- a/_authors/aandre.md
+++ b/_authors/aandre.md
@@ -3,5 +3,6 @@ layout: author
 login: aandre
 title: Alexandre Andre
 twitter: alexception_ck
+permalink: /authors/aandre/
 ---
 Astronaut, backend developer, PHP & Symfony lover. I should write something about myself but you know... developers.

--- a/_authors/captainjojo.md
+++ b/_authors/captainjojo.md
@@ -3,5 +3,6 @@ layout: author
 login: captainjojo
 title: Jonathan Jalouzot
 twitter: captainjojo42
+permalink: /authors/captainjojo/
 ---
 Lead développeur au @lemondefr, mes technologies sont le symfony depuis 2009, le nodejs, l'angularjs, rabbitMq etc ... J'adore les médias et aimerai continuer dans ce secteur plein de surprise. Vous pouvez me retrouver sur les réseaux sociaux: Twitter: @captainjojo42 Instagram: @captainjojo42 Linkedin: https://fr.linkedin.com/in/jonathanjalouzot Github: https://github.com/captainjojo

--- a/_authors/charles-eric.md
+++ b/_authors/charles-eric.md
@@ -3,5 +3,6 @@ layout: author
 login: charles-eric
 title: Charles-Eric Gorron
 twitter: ch3ric
+permalink: /authors/charles-eric/
 ---
 Web addict, Lead developer, Agile evangelist & SCRUM Master @ Eleven Labs

--- a/_authors/cmoncade.md
+++ b/_authors/cmoncade.md
@@ -2,5 +2,6 @@
 layout: author
 login: cmoncade
 title: Cédric Moncade
+permalink: /authors/cmoncade/
 ---
 Développeur PHP/Symfony depuis maintenant 4 ans, je m'interresse aux nouvelles technologies et en tant qu'Astronaute, conquérir de nouveaux bars.

--- a/_authors/damien.md
+++ b/_authors/damien.md
@@ -3,4 +3,5 @@ layout: author
 login: damien
 title: Damien Saillard
 twitter: daemon1981
+permalink: /authors/damien/
 ---

--- a/_authors/denis.md
+++ b/_authors/denis.md
@@ -2,4 +2,5 @@
 layout: author
 login: denis
 title: Denis Schneider
+permalink: /authors/denis/
 ---

--- a/_authors/ibenichou.md
+++ b/_authors/ibenichou.md
@@ -3,5 +3,6 @@ layout: author
 login: ibenichou
 title: Ilan Benichou
 twitter: IlanBenhamou
+permalink: /authors/ibenichou/
 ---
 Développeur Fullstack (PHP/JS/IOS/DEVOPS), j'adore découvrir de nouvelle chose, toujours prêt à relever un challenge.

--- a/_authors/jbernard.md
+++ b/_authors/jbernard.md
@@ -3,5 +3,6 @@ layout: author
 login: jbernard
 title: Jérémy Bernard
 twitter: bernar_w
+permalink: /authors/jbernard/
 ---
 Développeur Javascript actif. Et d'autre choses aussi.

--- a/_authors/jelhaouchi.md
+++ b/_authors/jelhaouchi.md
@@ -4,5 +4,6 @@ login: jelhaouchi
 name: Jawad Elhaouchi
 twitter: jelhaouchi
 github: jelhaouchi
+permalink: /authors/jelhaouchi/
 ---
 Curious Geek. Interests in open source, containers, microservices. Passionate about technology and startups. Climber and Surfer.

--- a/_authors/kelfarsaoui.md
+++ b/_authors/kelfarsaoui.md
@@ -4,5 +4,6 @@ login: kelfarsaoui
 title: Kamal Farsaoui
 twitter: elfakamal
 github: elfakamal
+permalink: /authors/kelfarsaoui/
 ---
 Web developer / Previously Founder & CEO at CSI, Co-Founder & CTO at Neiio / Coffee snob

--- a/_authors/nkania.md
+++ b/_authors/nkania.md
@@ -2,5 +2,6 @@
 layout: author
 login: nkania
 title: Noel Kania
+permalink: /authors/nkania/
 ---
 PHP, Symfony2, auto-hébergement, vps, bières...

--- a/_authors/obennouna.md
+++ b/_authors/obennouna.md
@@ -3,5 +3,6 @@ layout: author
 login: obennouna
 title: Omar Bennouna
 twitter: obennoun
+permalink: /authors/obennouna/
 ---
 Développeur Android essayant de chercher et comprendre les moindres recoins de ce que nous propose l'OS de Google

--- a/_authors/pouzor.md
+++ b/_authors/pouzor.md
@@ -3,12 +3,13 @@ layout: author
 login: pouzor
 name: Rémy Jardinet
 twitter: Pouz0r
+permalink: /authors/pouzor/
 ---
 Lead développeur chez France TV, je suis specialisé dans les technos back, avec une orientation DATA.
-Vous pouvez me retrouver sur les réseaux sociaux: 
+Vous pouvez me retrouver sur les réseaux sociaux:
 
-Twitter: @Pouz0r 
+Twitter: @Pouz0r
 
-Linkedin: https://www.linkedin.com/in/remyjardinet 
+Linkedin: https://www.linkedin.com/in/remyjardinet
 
 Github: https://github.com/Pouzor

--- a/_authors/qneyrat.md
+++ b/_authors/qneyrat.md
@@ -3,6 +3,7 @@ layout: author
 login: qneyrat
 title: Quentin Neyrat
 twitter: qneyrat
+permalink: /authors/qneyrat/
 ---
 
-Back-end developer @ Eleven Labs 
+Back-end developer @ Eleven Labs

--- a/_authors/rgraillon.md
+++ b/_authors/rgraillon.md
@@ -3,5 +3,6 @@ layout: author
 login: rgraillon
 title: Robin Graillon
 twitter: grailloute
+permalink: /authors/rgraillon/
 ---
 Robin est un développeur PHP/Symfony passionné. Il aime découvrir de nouvelles technologies, pratiquer plusieurs langages, et parler de lui à la 3ème personne.

--- a/_authors/rpierlot.md
+++ b/_authors/rpierlot.md
@@ -3,5 +3,6 @@ layout: author
 login: rpierlot
 title: Romain Pierlot
 twitter: RomainPierlot
+permalink: /authors/rpierlot/
 ---
 Diplomé de l'ISEP en 2013, Romain Pierlot est ingénieur en Etudes et Développement chez Eleven Labs, avec qui il s'amuse comme un petit fou.

--- a/_authors/thuchon.md
+++ b/_authors/thuchon.md
@@ -3,5 +3,6 @@ layout: author
 login: thuchon
 title: Thibaud Huchon
 twitter: ettibo
+permalink: /authors/thuchon/
 ---
 Plop

--- a/_authors/tthuon.md
+++ b/_authors/tthuon.md
@@ -2,5 +2,6 @@
 layout: author
 login: tthuon
 title: Thierry Thuon
+permalink: /authors/tthuon/
 ---
 Astronaute adepte de Symfony.

--- a/_authors/vcomposieux.md
+++ b/_authors/vcomposieux.md
@@ -3,5 +3,6 @@ layout: author
 login: vcomposieux
 title: Vincent Composieux
 twitter: vcomposieux
+permalink: /authors/vcomposieux/
 ---
 Architecte passionné par les technologies web depuis de longues années, je pratique principalement du PHP (Symfony) / Javascript mais aussi du Python ou Golang.


### PR DESCRIPTION
## Description

use permalink to create a folder per user with an `index.html` file inside

previous:
```
_site/
    authors/
        login.html
```

after:
```
_site/
    authors/
        login/
            index.html
```

Thanks to DirectoryIndex, this allow to use url like `/authors/login` in s3 website instead of `/authors/login.html`

## Preview

live example: http://dev.blog.eleven-labs.com.s3-website.eu-west-2.amazonaws.com/feat/authors-permalink/authors/vcomposieux/