### PR TITLE
feat(algolia): add link on logo

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -45,7 +45,9 @@
       htmlArticle += `
         <div class="container search-logo">
           search by
-          <span class="search-logo-bg"></span>
+          <a href="https://algolia.com" target="_blank">
+            <span class="search-logo-bg"></span>
+          </a>
         </div>
       `;
 


### PR DESCRIPTION
## Description

Algolia open source plan require a link to `https://algolia.com` on algolia logo which should be visible on search results

see https://www.algolia.com/for-open-source