### PR TITLE
feat(seo): add hreflang link attributes in head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     {% seo %}
+    <link rel="alternate" hreflang="fr" href="{{ site.url }}" />
+    <link rel="alternate" hreflang="en" href="{{ "/en" | prepend: site.url }}" />
 
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 


### PR DESCRIPTION
Issue: https://github.com/eleven-labs/eleven-labs.github.io/issues/26
Ajout des attributs `hreflang` comme spécifié sur cette documentation : https://support.google.com/webmasters/answer/189077?hl=en
Merci @seinhorn pour la suggestion.